### PR TITLE
30 tag get full tag structure fix

### DIFF
--- a/kepconfig/__init__.py
+++ b/kepconfig/__init__.py
@@ -18,6 +18,6 @@ r"""
 .. include:: ../README.md
 
 """
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 from . import connection, error
 

--- a/kepconfig/connectivity/tag.py
+++ b/kepconfig/connectivity/tag.py
@@ -480,6 +480,6 @@ def get_full_tag_structure(server: server, path: str, *, recursive: bool = False
     r['tag_groups'] = get_all_tag_groups(server, path, options= options)
     if recursive:
         for group in r['tag_groups']:
-            res = get_full_tag_structure(server, path + '.' + group['common.ALLTYPES_NAME'], options= options)
+            res = get_full_tag_structure(server, path + '.' + group['common.ALLTYPES_NAME'], recursive= recursive, options= options)
             group.update(res)
     return r


### PR DESCRIPTION
Update to fix recursive issue in retrieving full tag structure. This is merging the changes into the main branch.

This was back ported to the 1.1 release branch (https://github.com/PTCInc/Kepware-ConfigAPI-SDK-Python/tree/1.1_dev) for implementations supporting Python 3.6-3.8.